### PR TITLE
feat(gateway): support external frontend hosting with explicit allowed origins

### DIFF
--- a/examples/sim_config/lcnc_suite_sim.ini
+++ b/examples/sim_config/lcnc_suite_sim.ini
@@ -36,6 +36,11 @@ WEBUI_BROWSER = 1
 #   directly. Always 0 for shop-floor / production use.
 WEBUI_DEV = 0
 
+# WEBUI_FRONTEND: 1 = lcnc-suite serves its built SPA from the gateway.
+#   0 = gateway/API only; use an external frontend host instead.
+#   Default is 1.
+WEBUI_FRONTEND = 1
+
 # ── Logging ──────────────────────────────────────────────────────────
 # LOG_DIR: where all four suite processes (launcher, gateway, hal_reader,
 #   hal_watchdog) write their logs. OPTIONAL — leave it unset and logs go

--- a/examples/sim_config/lcnc_suite_sim.ini
+++ b/examples/sim_config/lcnc_suite_sim.ini
@@ -36,10 +36,18 @@ WEBUI_BROWSER = 1
 #   directly. Always 0 for shop-floor / production use.
 WEBUI_DEV = 0
 
-# WEBUI_FRONTEND: 1 = lcnc-suite serves its built SPA from the gateway.
-#   0 = gateway/API only; use an external frontend host instead.
+# WEBUI_FRONTEND:
+#   1 = lcnc-suite serves its built SPA from the gateway.
+#   0 = gateway/API only.
+#   /path/to/file = launch that frontend host alongside the gateway.
+#   /path/to/directory = serve that directory as static files.
 #   Default is 1.
 WEBUI_FRONTEND = 1
+
+# Host/port for an external WEBUI_FRONTEND file or directory.
+# Defaults: WEBUI_FRONTEND_HOST = WEBUI_HOST, WEBUI_FRONTEND_PORT = 8081.
+# WEBUI_FRONTEND_HOST = 0.0.0.0
+# WEBUI_FRONTEND_PORT = 8081
 
 # ── Logging ──────────────────────────────────────────────────────────
 # LOG_DIR: where all four suite processes (launcher, gateway, hal_reader,

--- a/lcnc-gateway/gateway.py
+++ b/lcnc-gateway/gateway.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import linuxcnc
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, List, Tuple
+from typing import Any, Dict, Optional, List, Set, Tuple
 from fastapi.staticfiles import StaticFiles
 import re
 import shutil
@@ -455,12 +455,16 @@ async def _reader_configure_extra_pins() -> None:
     """
     if not _hal_bridge.reader_connected:
         return
+    global _hal_diag_fields
     pins: Dict[str, str] = {}
     try:
         _settings = await asyncio.to_thread(load_settings)  # file read off the loop (B3)
+        pins.update(_settings_hal_diagnostic_pins(_settings))
+        _hal_diag_fields = list(pins.keys())
         slp = _settings.get("machine", {}).get("spindleLoadPin", "")
     except Exception:
         slp = ""
+        _hal_diag_fields = []
     if isinstance(slp, str) and _HAL_PIN_RE.match(slp):
         pins["spindle_load"] = slp
     try:
@@ -956,6 +960,9 @@ _halshow_topology_cache: Optional[dict] = None  # built-once HAL graph (P5); HAL
 _unacked_trip: Optional[dict] = None  # {"reason": str}
 _last_fault_latched: Optional[bool] = None  # webui-hb-latch.fault-out at last poll
 _trip_baseline_seen: bool = False  # have we ever seen the latch clear (FALSE)?
+_disable_reason: Optional[dict] = None
+_disable_history: list = []
+_DISABLE_HISTORY_MAX = 6
 
 # Warn-once flags for STAT field absence — the cascade itself is correct (different
 # LinuxCNC versions expose different fields), but exhausting all candidates without
@@ -976,6 +983,8 @@ _status_event: Optional[asyncio.Event] = None
 # asyncio.to_thread. Non-reentrant: helpers (_cmd_blocking, set_mode) assume
 # the caller already holds the lock.
 _cmd_lock: Optional[asyncio.Lock] = None
+_active_jog_axes: Set[Tuple[int, int]] = set()
+_JOG_STATUS_HZ = 8.0
 
 
 def _get_cmd_lock() -> asyncio.Lock:
@@ -984,9 +993,67 @@ def _get_cmd_lock() -> asyncio.Lock:
         _cmd_lock = asyncio.Lock()
     return _cmd_lock
 
+
+def _mark_jog_started(joint_flag: int, axis: int) -> None:
+    _active_jog_axes.add((int(joint_flag), int(axis)))
+
+
+def _mark_jog_stopped(joint_flag: int, axis: int) -> None:
+    _active_jog_axes.discard((int(joint_flag), int(axis)))
+
+
+def _mark_all_jogs_stopped() -> None:
+    _active_jog_axes.clear()
+
 # Timing log (toggled via "timing_log" WS command from Debug tab)
 _timing_log_enabled = False
 _timing_log_path: Optional[str] = None
+
+
+def _trim_disable_snapshot(status_dict: Optional[dict], errors: Optional[list], hal_diag: Optional[dict]) -> dict:
+    status_dict = status_dict or {}
+    work_pos = status_dict.get("work_pos") if isinstance(status_dict.get("work_pos"), list) else []
+    return {
+        "ts_ms": int(time.time() * 1000),
+        "task_mode": status_dict.get("task_mode"),
+        "motion_mode": status_dict.get("motion_mode"),
+        "interp_state": status_dict.get("interp_state"),
+        "emc_enable_in": status_dict.get("emc_enable_in"),
+        "joint_diagnostics": status_dict.get("joint_diagnostics") or [],
+        "recent_errors": list(errors or [])[-5:],
+        "hal_diag": hal_diag or {},
+        "positions": {
+            "x": work_pos[0] if len(work_pos) > 0 else None,
+            "y": work_pos[1] if len(work_pos) > 1 else None,
+            "z": work_pos[2] if len(work_pos) > 2 else None,
+            "a": work_pos[3] if len(work_pos) > 3 else None,
+            "b": work_pos[4] if len(work_pos) > 4 else None,
+            "c": work_pos[5] if len(work_pos) > 5 else None,
+        },
+    }
+
+
+def _record_disable_history(status_dict: Optional[dict], errors: Optional[list], hal_diag: Optional[dict]) -> None:
+    global _disable_history
+    _disable_history.append(_trim_disable_snapshot(status_dict, errors, hal_diag))
+    if len(_disable_history) > _DISABLE_HISTORY_MAX:
+        _disable_history = _disable_history[-_DISABLE_HISTORY_MAX:]
+
+
+def _build_disable_reason(*, changed: dict, current_status: dict, current_errors: list,
+                          current_hal_diag: Optional[dict], previous_hal_diag: Optional[dict]) -> dict:
+    previous_snapshot = _disable_history[-1] if _disable_history else None
+    return {
+        "kind": "machine_disabled",
+        "ts_ms": int(time.time() * 1000),
+        "changed": changed,
+        "recent_errors": list(current_errors or [])[-5:],
+        "previous_recent_errors": list(previous_snapshot.get("recent_errors", [])) if previous_snapshot else [],
+        "status": _trim_disable_snapshot(current_status, current_errors, current_hal_diag),
+        "previous_status": previous_snapshot,
+        "likely_causes": _hal_diag_likely_causes(current_hal_diag),
+        "previous_likely_causes": _hal_diag_likely_causes(previous_hal_diag),
+    }
 
 
 def _log_timing(timing: dict):
@@ -1036,6 +1103,35 @@ _PROBE_EVAL_RE = re.compile(
 )
 
 
+def _hal_diag_likely_causes(hal_diag: Optional[Dict[str, Any]]) -> List[str]:
+    if not isinstance(hal_diag, dict):
+        return []
+    causes: List[str] = []
+    false_is_bad = ("ok", "ready", "closed", "enable", "connected", "chain", "latch", "allowed")
+    true_is_bad = ("fault", "error", "trip", "tripped", "errored", "faulted")
+
+    for key, value in hal_diag.items():
+        lower_key = key.lower()
+        if "amp_enable" in lower_key:
+            continue
+        if value in (False, 0, 0.0) and any(token in lower_key for token in false_is_bad):
+            causes.append(f"{key} is false")
+        elif value in (True, 1, 1.0) and any(token in lower_key for token in true_is_bad):
+            causes.append(f"{key} is true")
+
+    for index in range(9):
+        cmd = hal_diag.get(f"joint{index}_cmd")
+        fb = hal_diag.get(f"joint{index}_fb")
+        if cmd is not None and fb is not None:
+            try:
+                delta = float(cmd) - float(fb)
+            except (TypeError, ValueError):
+                continue
+            if abs(delta) > 0.05:
+                causes.append(f"joint{index} following-error candidate: cmd/fb delta {delta:.4f}")
+    return causes
+
+
 async def _status_poller():
     """Single global poller — polls LinuxCNC once per cycle for all clients.
 
@@ -1054,6 +1150,10 @@ async def _status_poller():
     _last_pid_check = 0.0
     _cycle_start = time.monotonic()
     _was_active = True  # Experiment 4: track active/idle edge for instant wake-up
+    _last_safety_diag: Optional[Dict[str, Any]] = None
+    _last_hal_diag: Optional[Dict[str, Any]] = None
+    _last_jog_skip_log = 0.0
+    _last_jog_status_poll = 0.0
     # === IDLE-GATEWAY DIAGNOSTICS (permanent) === log when the gateway is up but no
     # clients are connected. Helps tell "all tabs reconnected fast" from
     # "tabs are stuck somewhere and never reaching us" in the log alone.
@@ -1113,6 +1213,25 @@ async def _status_poller():
                         lcnc_connected = False
                         continue
 
+            active_jog_poll = False
+            if _active_jog_axes:
+                jog_interval = 1.0 / _JOG_STATUS_HZ
+                if now - _last_jog_status_poll < jog_interval:
+                    if now - _last_jog_skip_log >= 1.0:
+                        _trace.emit("status.poll_throttled_for_jog",
+                                    active_jogs=sorted(_active_jog_axes),
+                                    target_hz=_JOG_STATUS_HZ)
+                        _last_jog_skip_log = now
+                    await asyncio.sleep(0.02)
+                    continue
+                _last_jog_status_poll = now
+                active_jog_poll = True
+                if now - _last_jog_skip_log >= 1.0:
+                    _trace.emit("status.poll_light_for_jog",
+                                active_jogs=sorted(_active_jog_axes),
+                                target_hz=_JOG_STATUS_HZ)
+                    _last_jog_skip_log = now
+
             # poll_status() blocks ~40ms (GIL held by C extensions).
             # run_in_executor lets the event loop serve HTTP (STL files)
             # between GIL switches during that time. asdict() runs in the
@@ -1122,13 +1241,17 @@ async def _status_poller():
             _set_phase("status_poller.poll_and_serialize")
             st, status_dict = await loop.run_in_executor(None, _poll_and_serialize)
             t1 = time.monotonic()
-            _set_phase("status_poller.read_errors")
-            # ERR.poll() is a C-extension call that holds the GIL for its
-            # NML read; running it inline on the main thread blocks the
-            # event loop in the same way STAT.poll does. Move it to the
-            # default executor so heartbeat / WS sends can interleave.
-            raw_errs = await loop.run_in_executor(None, read_errors_nonblocking)
-            t2 = time.monotonic()
+            if active_jog_poll:
+                raw_errs = []
+                t2 = t1
+            else:
+                _set_phase("status_poller.read_errors")
+                # ERR.poll() is a C-extension call that holds the GIL for its
+                # NML read; running it inline on the main thread blocks the
+                # event loop in the same way STAT.poll does. Move it to the
+                # default executor so heartbeat / WS sends can interleave.
+                raw_errs = await loop.run_in_executor(None, read_errors_nonblocking)
+                t2 = time.monotonic()
             _set_phase("status_poller.post_poll")
             _poll_fails = 0
 
@@ -1203,6 +1326,57 @@ async def _status_poller():
                     _trace.emit("comp.reload_req_failed", level="warn",
                                 exc=type(e).__name__, msg=str(e),
                                 hint="compensation.py not loaded?")
+
+            hal_diag = status_dict.get("hal_diag") if isinstance(status_dict, dict) else None
+            safety_diag = {
+                "stat_estop": bool(st.estop),
+                "stat_enabled": bool(st.enabled),
+                "merged_estop": bool(st.is_estop),
+                "merged_enabled": bool(st.is_enabled),
+                "emc_enable_in": st.emc_enable_in,
+                "trip_latched": _reader_get("trip_latched"),
+            }
+            machine_disabled = False
+            if _last_safety_diag is None:
+                _last_safety_diag = safety_diag
+                _last_hal_diag = hal_diag if isinstance(hal_diag, dict) else None
+            elif safety_diag != _last_safety_diag:
+                changed = {
+                    key: {"from": _last_safety_diag.get(key), "to": value}
+                    for key, value in safety_diag.items()
+                    if _last_safety_diag.get(key) != value
+                }
+                previous_causes = _hal_diag_likely_causes(_last_hal_diag)
+                current_causes = _hal_diag_likely_causes(hal_diag)
+                machine_disabled = _last_safety_diag.get("stat_enabled") is True and safety_diag.get("stat_enabled") is False
+                if machine_disabled:
+                    _disable_reason = _build_disable_reason(
+                        changed=changed,
+                        current_status=status_dict,
+                        current_errors=errs,
+                        current_hal_diag=hal_diag if isinstance(hal_diag, dict) else None,
+                        previous_hal_diag=_last_hal_diag,
+                    )
+                print(
+                    "[HAL-DIAG] safety transition " + json.dumps({
+                        "changed": changed,
+                        "likely_causes": current_causes,
+                        "previous_likely_causes": previous_causes if machine_disabled else [],
+                        "safety": safety_diag,
+                        "hal_diag": hal_diag,
+                        "previous_hal_diag": _last_hal_diag if machine_disabled else None,
+                    }, sort_keys=True, default=str),
+                    flush=True,
+                )
+                _last_safety_diag = safety_diag
+                _last_hal_diag = hal_diag if isinstance(hal_diag, dict) else None
+            else:
+                _last_hal_diag = hal_diag if isinstance(hal_diag, dict) else None
+
+            if not machine_disabled:
+                _record_disable_history(status_dict, errs, hal_diag if isinstance(hal_diag, dict) else None)
+            if safety_diag.get("stat_enabled") is True:
+                _disable_reason = None
 
             # Comp grid startup init: push existing probe-results-grid.json on first connect
             if not _bulk.grid_initialized and getattr(STAT, "ini_filename", None):
@@ -1607,6 +1781,7 @@ _status_runtime = _status_runtime_mod.StatusRuntime(
     get_stat=lambda: STAT,
     get_err=lambda: ERR,
     reader_get=_hal_bridge.reader_get,
+    get_hal_diag_fields=lambda: list(_hal_diag_fields),
     get_tool_tbl_path=lambda: get_tool_tbl_path(),
     load_tool_library=lambda: load_tool_library(),
     get_fb_scale=lambda: _fb_scale,
@@ -1936,6 +2111,24 @@ SETTINGS_PATH = BASE_DIR / "settings.json"
 _fb_scale = 60  # spindle feedback scale: 60 (RPS→RPM) or 1 (already RPM)
 _spindle_load_pin = ""  # HAL pin for spindle load %, empty = disabled
 _HAL_PIN_RE = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_.:-]*$')
+_HAL_FIELD_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+_hal_diag_fields: List[str] = []
+
+
+def _get_hal_diag_fields() -> List[str]:
+    return list(_hal_diag_fields)
+
+
+def _settings_hal_diagnostic_pins(settings: dict) -> Dict[str, str]:
+    raw = settings.get("machine", {}).get("halDiagnosticPins", {})
+    if not isinstance(raw, dict):
+        return {}
+    pins: Dict[str, str] = {}
+    for field, pin in raw.items():
+        if isinstance(field, str) and isinstance(pin, str) \
+                and _HAL_FIELD_RE.match(field) and _HAL_PIN_RE.match(pin):
+            pins[field] = pin
+    return pins
 
 
 def _settings_load_error(e: Exception) -> None:
@@ -2140,6 +2333,19 @@ def _jog_joint_flag() -> int:
     return 1
 
 
+def _jog_joint_flag_for_msg(msg: dict) -> int:
+    if bool(msg.get("joint", False)):
+        return 1
+    return _jog_joint_flag()
+
+
+async def _prepare_jog_mode(msg: dict) -> int:
+    await set_mode(linuxcnc.MODE_MANUAL)
+    joint_jog = bool(msg.get("joint", False))
+    await _cmd_blocking(CMD.teleop_enable, 0 if joint_jog else 1)
+    return 1 if joint_jog else 0
+
+
 async def _jog_stop_for_client() -> None:
     """Jog-stop every joint as part of a client disarm. Caller must hold _cmd_lock.
 
@@ -2176,10 +2382,12 @@ async def _jog_stop_for_client() -> None:
     if not homed:
         return  # nothing to jog-stop if not homed
     await set_mode(linuxcnc.MODE_MANUAL)
-    jf = _jog_joint_flag()
+    await _cmd_blocking(CMD.teleop_enable, 0)
+    jf = 1
     _nj = getattr(STAT, "joints", 3) if STAT else 3
     for ax in range(_nj):
         await _cmd_blocking(CMD.jog, linuxcnc.JOG_STOP, jf, ax, wait=None)
+    _mark_all_jogs_stopped()
 
 
 def require_armed(armed: bool):
@@ -2827,9 +3035,9 @@ async def _handle_command_impl(msg: Dict[str, Any], armed: bool):
 
             axis = finite_int(msg.get("axis"), lo=0)
             vel = finite_float(msg.get("vel", 0.0))
-            await set_mode(linuxcnc.MODE_MANUAL)
-            jf = _jog_joint_flag()
+            jf = await _prepare_jog_mode(msg)
             await _cmd_blocking(CMD.jog, linuxcnc.JOG_CONTINUOUS, jf, axis, vel, wait=None)
+            _mark_jog_started(jf, axis)
             return {"ok": True}
 
         if cmd == "jog_stop":
@@ -2846,9 +3054,11 @@ async def _handle_command_impl(msg: Dict[str, Any], armed: bool):
             if mode == linuxcnc.MODE_AUTO and interp != linuxcnc.INTERP_IDLE:
                 return {"ok": True}
             axis = finite_int(msg.get("axis"), lo=0)
-            await set_mode(linuxcnc.MODE_MANUAL)
-            jf = _jog_joint_flag()
-            await _cmd_blocking(CMD.jog, linuxcnc.JOG_STOP, jf, axis, wait=None)
+            jf = 1 if bool(msg.get("joint", False)) else 0
+            try:
+                await _cmd_blocking(CMD.jog, linuxcnc.JOG_STOP, jf, axis, wait=None)
+            finally:
+                _mark_jog_stopped(jf, axis)
             return {"ok": True}
 
         if cmd == "jog_cont_multi":
@@ -2859,10 +3069,11 @@ async def _handle_command_impl(msg: Dict[str, Any], armed: bool):
                 return blocked
 
             axes = msg.get("axes", [])
-            await set_mode(linuxcnc.MODE_MANUAL)
-            jf = _jog_joint_flag()
+            jf = await _prepare_jog_mode(msg)
             for entry in axes:
-                await _cmd_blocking(CMD.jog, linuxcnc.JOG_CONTINUOUS, jf, finite_int(entry["axis"], lo=0), finite_float(entry["vel"]), wait=None)
+                axis = finite_int(entry["axis"], lo=0)
+                await _cmd_blocking(CMD.jog, linuxcnc.JOG_CONTINUOUS, jf, axis, finite_float(entry["vel"]), wait=None)
+                _mark_jog_started(jf, axis)
             return {"ok": True}
 
         if cmd == "jog_stop_multi":
@@ -2874,10 +3085,13 @@ async def _handle_command_impl(msg: Dict[str, Any], armed: bool):
             if mode == linuxcnc.MODE_AUTO and interp != linuxcnc.INTERP_IDLE:
                 return {"ok": True}
             axes = msg.get("axes", [])
-            await set_mode(linuxcnc.MODE_MANUAL)
-            jf = _jog_joint_flag()
+            jf = 1 if bool(msg.get("joint", False)) else 0
             for a in axes:
-                await _cmd_blocking(CMD.jog, linuxcnc.JOG_STOP, jf, finite_int(a, lo=0), wait=None)
+                axis = finite_int(a, lo=0)
+                try:
+                    await _cmd_blocking(CMD.jog, linuxcnc.JOG_STOP, jf, axis, wait=None)
+                finally:
+                    _mark_jog_stopped(jf, axis)
             return {"ok": True}
 
         if cmd == "jog_incr":
@@ -2890,8 +3104,7 @@ async def _handle_command_impl(msg: Dict[str, Any], armed: bool):
             axis = finite_int(msg.get("axis"), lo=0)
             vel = abs(finite_float(msg.get("vel", 0.0)))  # speed only; distance carries direction
             dist = finite_float(msg.get("distance", 0.0))
-            await set_mode(linuxcnc.MODE_MANUAL)
-            jf = _jog_joint_flag()
+            jf = await _prepare_jog_mode(msg)
             await _cmd_blocking(CMD.jog, linuxcnc.JOG_INCREMENT, jf, axis, vel, dist, wait=None)
             return {"ok": True}
 
@@ -2903,8 +3116,7 @@ async def _handle_command_impl(msg: Dict[str, Any], armed: bool):
                 return blocked
 
             axes = msg.get("axes", [])
-            await set_mode(linuxcnc.MODE_MANUAL)
-            jf = _jog_joint_flag()
+            jf = await _prepare_jog_mode(msg)
             for entry in axes:
                 await _cmd_blocking(CMD.jog, linuxcnc.JOG_INCREMENT, jf, finite_int(entry["axis"], lo=0), abs(finite_float(entry["vel"])), finite_float(entry["distance"]), wait=None)
             return {"ok": True}
@@ -4827,6 +5039,7 @@ async def ws_endpoint(ws: WebSocket):
                         clients_list=_shared_clients_list,
                         armed=client.armed,
                         safety_trip=_unacked_trip,
+                        disable_reason=_disable_reason,
                         reader_stale=_reader_is_stale(),
                         config_warning=(
                             {
@@ -4958,7 +5171,7 @@ async def ws_endpoint(ws: WebSocket):
                             _new_load_pin = _slp if isinstance(_slp, str) and _HAL_PIN_RE.match(_slp) else ""
                             if _new_load_pin != _spindle_load_pin:
                                 _spindle_load_pin = _new_load_pin
-                                asyncio.create_task(_reader_configure_extra_pins())
+                            asyncio.create_task(_reader_configure_extra_pins())
                             await ws_send_json(ws, {
                                 "type": "settings_changed",
                                 "settings": _ss,

--- a/lcnc-gateway/gateway_util.py
+++ b/lcnc-gateway/gateway_util.py
@@ -88,6 +88,7 @@ def origin_allowed(
       This is the gateway's own served page on whatever LAN IP was browsed to,
       and needs no configuration.
     - Origin listed in the explicit allowlist or dev extras → allow.
+    - A literal `*` in either list → allow any browser origin.
     - Otherwise → reject.
 
     The explicit allowlist ADDS to the same-host default rather than replacing
@@ -97,10 +98,14 @@ def origin_allowed(
         return True
     if _origin_host_matches(origin, host):
         return True
-    if allowlist and origin in set(allowlist):
-        return True
-    if extra_allowed and origin in set(extra_allowed):
-        return True
+    if allowlist:
+        allowset = set(allowlist)
+        if "*" in allowset or origin in allowset:
+            return True
+    if extra_allowed:
+        extraset = set(extra_allowed)
+        if "*" in extraset or origin in extraset:
+            return True
     return False
 
 

--- a/lcnc-gateway/hal_bridge.py
+++ b/lcnc-gateway/hal_bridge.py
@@ -4,18 +4,20 @@ Owns the two Unix-socket clients connecting the gateway to its HAL sibling
 processes (the gateway never imports `hal` — see GitHub issue #9):
 
 - **watchdog socket** (`hal_watchdog.py`, default ``/tmp/webui-safety.sock``):
-  bounded sends of pin-update messages (heartbeat / connected / trip_reset /
-  tool_changed). The socket carries a tight 50 ms sendall timeout so a
+    bounded sends of freshness and pin-update messages (heartbeat / connected /
+    trip_reset / tool_changed). The watchdog process owns the short-period HAL
+    heartbeat generation; gateway heartbeat messages refresh its liveness window.
+    The socket carries a tight 50 ms sendall timeout so a
   scheduling-delayed watchdog can never stall the event loop — a timed-out
-  send is a *dropped* message, and the HAL oneshot trips correctly on its own
-  if heartbeats truly stop arriving.
+    send is a *dropped* refresh, and the HAL oneshot trips correctly on its own
+    if gateway freshness updates truly stop arriving.
 - **reader socket** (`hal_reader.py`, default ``/tmp/webui-reader.sock``):
   30 Hz pin-snapshot push plus request/reply RPC (set_p, halshow_dump,
   set_extra_pins), and snapshot freshness (`reader_is_stale`).
 
-IMPORTANT BOUNDARY (modularization plan, M6): the gateway heartbeat coroutine
-stays in gateway.py. This module *transports* heartbeat values handed to
-``watchdog_send`` but must never produce one.
+IMPORTANT BOUNDARY (modularization plan, M6): this module transports watchdog
+messages handed to ``watchdog_send`` but must never generate HAL heartbeat
+edges itself.
 
 Gateway-side dependencies are injected (``set_phase`` for stall forensics,
 ``on_reader_connect`` for the extra-pin push policy) so this module has no

--- a/lcnc-gateway/hal_reader.py
+++ b/lcnc-gateway/hal_reader.py
@@ -16,8 +16,9 @@ Two responsibilities, both over a single Unix socket:
      - "halshow_dump"   → hal.get_info_pins/signals/params for the diag tab
 
 Why split this from hal_watchdog.py?  hal_watchdog is the safety-supervisor
-process — it generates the gateway heartbeat and pulses the HAL trip-latch's
-reset (the latch itself is a servo-thread estop_latch, webui-hb-latch, #34).
+process — it generates the local HAL heartbeat from gateway freshness updates
+and pulses the HAL trip-latch's reset (the latch itself is a servo-thread
+estop_latch, webui-hb-latch, #34).
 Keeping it small and single-purpose makes it easier to audit.  hal_reader is
 pure observation
 (plus a couple of writes); its failure mode is "display values stale, comp

--- a/lcnc-gateway/hal_watchdog.py
+++ b/lcnc-gateway/hal_watchdog.py
@@ -2,8 +2,9 @@
 """HAL watchdog for webui-safety.
 
 Loaded by LinuxCNC HAL config:  loadusr -W hal_watchdog.py
-Listens for gateway heartbeat updates on a Unix socket.
-When gateway disconnects, heartbeat stops toggling → downstream watchdog trips.
+Listens for gateway freshness updates on a Unix socket.
+When gateway disconnects or stops refreshing this process, the local heartbeat
+stops toggling → downstream watchdog trips.
 Pins survive gateway restart because this component is owned by LinuxCNC.
 """
 import os
@@ -171,6 +172,30 @@ def _stop(*_):
 signal.signal(signal.SIGTERM, _stop)
 signal.signal(signal.SIGINT, _stop)
 
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        value = float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, value))
+
+
+_LOCAL_HEARTBEAT_HZ = _env_float("LCNC_WATCHDOG_LOCAL_HEARTBEAT_HZ", 30.0, 2.0, 100.0)
+_LOCAL_HEARTBEAT_PERIOD_S = 1.0 / _LOCAL_HEARTBEAT_HZ
+# LinuxCNC NML calls can occasionally hold the gateway interpreter long enough
+# to miss the old 500ms HAL heartbeat window. The separate watchdog process now
+# absorbs those short gateway stalls, but still trips if the gateway really stops
+# refreshing it. Keep this above observed multi-second STAT.poll stalls; override
+# with LCNC_WATCHDOG_GATEWAY_TIMEOUT_S for stricter deployments.
+_GATEWAY_FRESH_TIMEOUT_S = _env_float("LCNC_WATCHDOG_GATEWAY_TIMEOUT_S", 5.0, 1.0, 30.0)
+_SELECT_TIMEOUT_S = min(0.1, _LOCAL_HEARTBEAT_PERIOD_S)
+_gateway_fresh_at = None
+_gateway_requested_connected = False
+_gateway_stale_reported = False
+_local_heartbeat = False
+_local_heartbeat_at = time.monotonic()
+
 # wd.tick_summary is emitted once per N ticks (~1 s at 10 Hz select
 # cadence) by the shared Aggregator. `msgs`/`client_inq`/`reset_out`/
 # `hb_ok` are point-in-time at emit (extras callback resets msgs).
@@ -195,14 +220,44 @@ _wd_tick_agg = _trace.Aggregator(
 
 try:
     while _running:
+        now = time.monotonic()
+        gateway_fresh = (
+            client is not None
+            and _gateway_requested_connected
+            and _gateway_fresh_at is not None
+            and now - _gateway_fresh_at <= _GATEWAY_FRESH_TIMEOUT_S
+        )
+        if gateway_fresh:
+            _gateway_stale_reported = False
+            comp["connected"] = True
+            if now - _local_heartbeat_at >= _LOCAL_HEARTBEAT_PERIOD_S:
+                _local_heartbeat = not _local_heartbeat
+                comp["heartbeat"] = _local_heartbeat
+                _local_heartbeat_at = now
+        else:
+            if (_gateway_requested_connected and client is not None
+                    and _gateway_fresh_at is not None and not _gateway_stale_reported):
+                stale_ms = int((now - _gateway_fresh_at) * 1000)
+                print(f"[WD-STALE] gateway freshness timeout {stale_ms}ms", flush=True)
+                _trace.emit("wd.gateway_stale", level="error", stale_ms=stale_ms,
+                            timeout_ms=int(_GATEWAY_FRESH_TIMEOUT_S * 1000))
+                _gateway_stale_reported = True
+            if comp["heartbeat"]:
+                comp["heartbeat"] = False
+            _local_heartbeat = False
+            _local_heartbeat_at = now
+            if _gateway_requested_connected and client is not None and _gateway_fresh_at is not None:
+                comp["connected"] = False
+
         socks = [server]
         if client is not None:
             socks.append(client)
 
-        # 100ms select timeout → edge polling at ~10Hz. oneshot width is 500ms,
-        # so a trip window is always ≥500ms wide; 100ms resolution never misses.
+        # The watchdog process owns the HAL heartbeat cadence. The timeout is
+        # therefore bounded by the local heartbeat period, not by gateway event
+        # loop scheduling. oneshot width is 500ms, so 30Hz leaves ample margin.
         _select_t0 = time.monotonic()
-        readable, _, _ = select.select(socks, [], [], 0.1)
+        readable, _, _ = select.select(socks, [], [], _SELECT_TIMEOUT_S)
         _select_dt = (time.monotonic() - _select_t0) * 1000
         _wd_tick_agg.record(select_ms=_select_dt)
 
@@ -245,6 +300,11 @@ try:
                 comp["heartbeat"] = False
                 comp["tool-changed"] = False
                 comp["compensation-enable"] = False
+                _gateway_requested_connected = False
+                _gateway_stale_reported = False
+                _gateway_fresh_at = None
+                _local_heartbeat = False
+                _local_heartbeat_at = time.monotonic()
                 client = new_client
                 buf = ""
             elif sock is client:
@@ -256,6 +316,11 @@ try:
                         comp["heartbeat"] = False
                         comp["tool-changed"] = False
                         comp["compensation-enable"] = False
+                        _gateway_requested_connected = False
+                        _gateway_stale_reported = False
+                        _gateway_fresh_at = None
+                        _local_heartbeat = False
+                        _local_heartbeat_at = time.monotonic()
                         client.close()
                         client = None
                         buf = ""
@@ -311,9 +376,20 @@ try:
                                             _hb_recv_flush(f"gap_{rising_gap_ms}ms")
                                 _last_hb_recv_true = _now
                             _last_hb_recv = _now
-                            comp["heartbeat"] = _new_val
+                            _gateway_fresh_at = _now
+                            _gateway_stale_reported = False
                         if "connected" in msg:
-                            comp["connected"] = bool(msg["connected"])
+                            _gateway_requested_connected = bool(msg["connected"])
+                            if _gateway_requested_connected:
+                                _gateway_fresh_at = time.monotonic()
+                                _gateway_stale_reported = False
+                            else:
+                                comp["connected"] = False
+                                comp["heartbeat"] = False
+                                _gateway_fresh_at = None
+                                _gateway_stale_reported = False
+                                _local_heartbeat = False
+                                _local_heartbeat_at = time.monotonic()
                         if "tool_changed" in msg:
                             comp["tool-changed"] = bool(msg["tool_changed"])
                         if "compensation_enable" in msg:
@@ -336,6 +412,11 @@ try:
                     comp["heartbeat"] = False
                     comp["tool-changed"] = False
                     comp["compensation-enable"] = False
+                    _gateway_requested_connected = False
+                    _gateway_stale_reported = False
+                    _gateway_fresh_at = None
+                    _local_heartbeat = False
+                    _local_heartbeat_at = time.monotonic()
                     try:
                         client.close()
                     except Exception:

--- a/lcnc-gateway/status_runtime.py
+++ b/lcnc-gateway/status_runtime.py
@@ -106,6 +106,7 @@ class StatusPayload:
     # command is silently missed (issue #14). None ⇒ reader snapshot stale
     # or pin unavailable; the existing reader_stale banner surfaces that.
     emc_enable_in: Optional[bool]
+    hal_diag: Optional[Dict[str, Any]]
     homed: Optional[bool]  # LinuxCNC stat truth (normalized)
     homed_joints: Optional[list]  # per-joint homed mask (configured joints only)
 
@@ -129,6 +130,7 @@ class StatusPayload:
     rotation_xy: Optional[float]
     wcs_table: Optional[List[Dict[str, Any]]]  # all 9 WCS slots (G54–G59.3) w/ per-axis + rotation
     joint_pos: Optional[List[float]]
+    joint_diagnostics: Optional[List[Dict[str, Any]]]
     tool_offset: Optional[List[float]]
     machine_pos: Optional[List[float]]
     work_pos: Optional[List[float]]
@@ -229,6 +231,20 @@ def policy_state_from_payload(p: "StatusPayload", armed: bool) -> _PolicyMachine
     )
 
 
+def _finite_or_none(value) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _bool_or_none(value) -> Optional[bool]:
+    if value is None:
+        return None
+    return bool(value)
+
+
 class StatusRuntime:
     def __init__(
         self,
@@ -239,10 +255,12 @@ class StatusRuntime:
         get_tool_tbl_path: Callable[[], Optional[str]],
         load_tool_library: Callable[[], dict],
         get_fb_scale: Callable[[], float],
+        get_hal_diag_fields: Optional[Callable[[], List[str]]] = None,
     ) -> None:
         self._get_stat = get_stat
         self._get_err = get_err
         self._reader_get = reader_get
+        self._get_hal_diag_fields = get_hal_diag_fields or (lambda: [])
         self._get_tool_tbl_path = get_tool_tbl_path
         self._load_tool_library = load_tool_library
         self._get_fb_scale = get_fb_scale
@@ -601,6 +619,39 @@ class StatusRuntime:
             jpos = safe_get("joint_position", None)
         joint_pos = to_float_list(jpos)
 
+        joint_diagnostics = None
+        joint_rows = safe_get("joint", None)
+        if joint_rows is not None:
+            try:
+                joint_diagnostics = []
+                for index, joint in enumerate(joint_rows[:nj] if nj else joint_rows):
+                    if joint is None:
+                        joint_diagnostics.append({"index": index})
+                        continue
+                    get = joint.get if isinstance(joint, dict) else lambda key, default=None: getattr(joint, key, default)
+                    joint_diagnostics.append({
+                        "index": index,
+                        "type": get("jointType", None),
+                        "enabled": _bool_or_none(get("enabled", None)),
+                        "homed": _bool_or_none(get("homed", None)),
+                        "homing": _bool_or_none(get("homing", None)),
+                        "inpos": _bool_or_none(get("inpos", None)),
+                        "fault": _bool_or_none(get("fault", None)),
+                        "min_soft_limit": _bool_or_none(get("min_soft_limit", None)),
+                        "max_soft_limit": _bool_or_none(get("max_soft_limit", None)),
+                        "min_hard_limit": _bool_or_none(get("min_hard_limit", None)),
+                        "max_hard_limit": _bool_or_none(get("max_hard_limit", None)),
+                        "ferror_current": _finite_or_none(get("ferror_current", None)),
+                        "ferror_highmark": _finite_or_none(get("ferror_highmark", None)),
+                        "min_ferror": _finite_or_none(get("min_ferror", None)),
+                        "max_ferror": _finite_or_none(get("max_ferror", None)),
+                        "input": _finite_or_none(get("input", None)),
+                    })
+            except Exception as e:
+                _trace.emit("joint_diag.collect_failed", level="warn",
+                            exc=type(e).__name__, msg=str(e))
+                joint_diagnostics = None
+
         dtg = to_float_list(safe_get("dtg", None))
 
         # ---- velocity & spindle ----
@@ -685,11 +736,15 @@ class StatusRuntime:
             bool(safe_get("paused", False)),
         )
 
+        hal_diag_fields = self._get_hal_diag_fields()
+        hal_diag = {field: reader_get(field) for field in hal_diag_fields}
+
         payload = StatusPayload(
             ts=time.time(),
             estop=estop,
             enabled=enabled,
             emc_enable_in=reader_get("emc_enable_in"),
+            hal_diag=hal_diag,
             homed=homed,
             homed_joints=homed_joints,
             task_mode=safe_get("task_mode", None),
@@ -709,6 +764,7 @@ class StatusRuntime:
             rotation_xy=rotation_xy,
             wcs_table=[row.copy() for row in self.wcs_cache],
             joint_pos=joint_pos,
+            joint_diagnostics=joint_diagnostics,
             tool_offset=tool_offset,
             machine_pos=machine_pos,
             work_pos=work_pos,       # <-- tool-tip work coords

--- a/lcnc-gateway/test_ws_fanout.py
+++ b/lcnc-gateway/test_ws_fanout.py
@@ -32,6 +32,12 @@ class TestBuildStatusEnvelope(unittest.TestCase):
         self.assertIs(msg["safety_trip"], trip)
         self.assertNotIn("safety_trip", build_status_envelope(**self.BASE))
 
+    def test_disable_reason_attached_only_when_present(self):
+        reason = {"kind": "machine_disabled", "message": "disabled unexpectedly"}
+        msg = build_status_envelope(**self.BASE, disable_reason=reason)
+        self.assertIs(msg["disable_reason"], reason)
+        self.assertNotIn("disable_reason", build_status_envelope(**self.BASE))
+
     def test_reader_stale_flag(self):
         self.assertTrue(
             build_status_envelope(**self.BASE, reader_stale=True)["reader_stale"])

--- a/lcnc-gateway/ws_fanout.py
+++ b/lcnc-gateway/ws_fanout.py
@@ -145,6 +145,7 @@ def build_status_envelope(
     clients_list: Any,
     armed: bool,
     safety_trip: Optional[dict] = None,
+    disable_reason: Optional[dict] = None,
     reader_stale: bool = False,
     config_warning: Optional[dict] = None,
     probe_results: Optional[dict] = None,
@@ -167,6 +168,8 @@ def build_status_envelope(
     }
     if safety_trip is not None:
         msg["safety_trip"] = safety_trip
+    if disable_reason is not None:
+        msg["disable_reason"] = disable_reason
     if reader_stale:
         msg["reader_stale"] = True
     if config_warning is not None:

--- a/lcnc-suite
+++ b/lcnc-suite
@@ -38,6 +38,8 @@ if [[ -n "$INI_FILE" ]]; then
   BROWSER="${LCNC_WEBUI_BROWSER:-$(ini_get WEBUI_BROWSER)}"
   DEV="${LCNC_WEBUI_DEV:-$(ini_get WEBUI_DEV)}"
   FRONTEND="${LCNC_WEBUI_FRONTEND:-$(ini_get WEBUI_FRONTEND)}"
+  FRONTEND_HOST="${LCNC_WEBUI_FRONTEND_HOST:-$(ini_get WEBUI_FRONTEND_HOST)}"
+  FRONTEND_PORT="${LCNC_WEBUI_FRONTEND_PORT:-$(ini_get WEBUI_FRONTEND_PORT)}"
   CAM_SOURCE="${LCNC_CAMERA_SOURCE:-$(ini_get CAMERA_SOURCE)}"
   CAM_RES="${LCNC_CAMERA_RESOLUTION:-$(ini_get CAMERA_RESOLUTION)}"
   CAM_FPS="${LCNC_CAMERA_FPS:-$(ini_get CAMERA_FPS)}"
@@ -56,6 +58,8 @@ else
   BROWSER="${LCNC_WEBUI_BROWSER:-}"
   DEV="${LCNC_WEBUI_DEV:-}"
   FRONTEND="${LCNC_WEBUI_FRONTEND:-}"
+  FRONTEND_HOST="${LCNC_WEBUI_FRONTEND_HOST:-}"
+  FRONTEND_PORT="${LCNC_WEBUI_FRONTEND_PORT:-}"
   CAM_SOURCE="${LCNC_CAMERA_SOURCE:-}"
   CAM_RES="${LCNC_CAMERA_RESOLUTION:-}"
   CAM_FPS="${LCNC_CAMERA_FPS:-}"
@@ -76,8 +80,62 @@ PORT="${PORT:-8000}"
 BROWSER="${BROWSER:-1}"
 DEV="${DEV:-0}"
 FRONTEND="${FRONTEND:-1}"
+FRONTEND_HOST="${FRONTEND_HOST:-$HOST}"
+FRONTEND_PORT="${FRONTEND_PORT:-8081}"
 
 VITE_PORT="5173"
+
+_is_falsey() {
+  case "${1,,}" in
+    ""|0|false|no|off|none)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+_is_builtin_frontend() {
+  case "${1,,}" in
+    1|true|yes|on|builtin|dist|default)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+_resolve_frontend_path() {
+  local value="$1"
+  local base_dir=""
+  if [[ -n "$INI_FILE" ]]; then
+    base_dir="$(dirname "$INI_FILE")"
+  fi
+
+  if [[ "$value" = /* ]]; then
+    printf '%s' "$value"
+  elif [[ -n "$base_dir" ]]; then
+    printf '%s/%s' "$base_dir" "$value"
+  else
+    printf '%s/%s' "$PWD" "$value"
+  fi
+}
+
+FRONTEND_MODE=""
+FRONTEND_PATH=""
+if _is_builtin_frontend "$FRONTEND"; then
+  FRONTEND_MODE="builtin"
+elif _is_falsey "$FRONTEND"; then
+  FRONTEND_MODE="none"
+else
+  FRONTEND_PATH="$(_resolve_frontend_path "$FRONTEND")"
+  if [[ -d "$FRONTEND_PATH" ]]; then
+    FRONTEND_MODE="static"
+  elif [[ -f "$FRONTEND_PATH" ]]; then
+    FRONTEND_MODE="command"
+  else
+    echo "ERROR: WEBUI_FRONTEND path not found: $FRONTEND_PATH" >&2
+    exit 1
+  fi
+fi
 
 # ── Fail closed: refuse to expose the control plane on a non-loopback
 # interface without an auth token (issue #17). A LAN-reachable gateway with
@@ -264,17 +322,76 @@ UVICORN_WS=(--ws-per-message-deflate false)
 # means the HAL components shut down cleanly even when the gateway
 # is killed mid-flight.
 _wait_or_kill() {
-    local pid="$1" tag="$2"
+  local pid="$1" tag="$2" proc_name="${3:-process}"
     local i
     for i in {1..20}; do
         kill -0 "$pid" 2>/dev/null || break
         sleep 0.1
     done
     if kill -0 "$pid" 2>/dev/null; then
-        _log "$tag _term: gateway pid=$pid did not exit in 2s, SIGKILL"
+    _log "$tag _term: $proc_name pid=$pid did not exit in 2s, SIGKILL"
         kill -KILL "$pid" 2>/dev/null
     fi
     wait "$pid" 2>/dev/null || true
+}
+
+FRONTEND_PID=""
+FRONTEND_URL=""
+
+_start_frontend_host() {
+  local gateway_host="127.0.0.1"
+  local browser_host="$FRONTEND_HOST"
+
+  if [[ "$browser_host" == "0.0.0.0" ]]; then
+    browser_host="localhost"
+  fi
+  FRONTEND_URL="http://$browser_host:$FRONTEND_PORT/"
+
+  case "$FRONTEND_MODE" in
+    command)
+      if [[ "$FRONTEND_PATH" == *.js || "$FRONTEND_PATH" == *.mjs || "$FRONTEND_PATH" == *.cjs ]]; then
+        if ! command -v node >/dev/null 2>&1; then
+          echo "ERROR: node is required to run WEBUI_FRONTEND=$FRONTEND_PATH" >&2
+          return 1
+        fi
+        setsid env \
+          PORT="$FRONTEND_PORT" \
+          HOST="$FRONTEND_HOST" \
+          LCNC_INTERNAL_HOST="$gateway_host" \
+          LCNC_INTERNAL_PORT="$PORT" \
+          LCNC_WEBUI_TOKEN="$TOKEN" \
+          node "$FRONTEND_PATH" &
+      elif [[ -x "$FRONTEND_PATH" ]]; then
+        setsid env \
+          PORT="$FRONTEND_PORT" \
+          HOST="$FRONTEND_HOST" \
+          LCNC_INTERNAL_HOST="$gateway_host" \
+          LCNC_INTERNAL_PORT="$PORT" \
+          LCNC_WEBUI_TOKEN="$TOKEN" \
+          "$FRONTEND_PATH" &
+      else
+        echo "ERROR: WEBUI_FRONTEND file is not executable: $FRONTEND_PATH" >&2
+        echo "Make it executable or point WEBUI_FRONTEND at a directory for static hosting." >&2
+        return 1
+      fi
+      FRONTEND_PID=$!
+      _log "PROD frontend command started pid=$FRONTEND_PID path=$FRONTEND_PATH url=$FRONTEND_URL"
+      ;;
+    static)
+      setsid python3 -m http.server "$FRONTEND_PORT" --bind "$FRONTEND_HOST" --directory "$FRONTEND_PATH" &
+      FRONTEND_PID=$!
+      _log "PROD frontend static host started pid=$FRONTEND_PID dir=$FRONTEND_PATH url=$FRONTEND_URL"
+      ;;
+  esac
+}
+
+_stop_frontend_host() {
+  if [[ -n "$FRONTEND_PID" ]]; then
+    _log "PROD _term: SIGTERM → frontend pgid=$FRONTEND_PID"
+    kill -TERM -- -"$FRONTEND_PID" 2>/dev/null || true
+    _wait_or_kill "$FRONTEND_PID" "PROD" "frontend"
+    FRONTEND_PID=""
+  fi
 }
 
 # === TEMP HAL-SAMPLE PROBE === capture every servo-cycle value of the
@@ -351,21 +468,25 @@ _start_proc_status_loop() {
         while kill -0 "$gw_pid" 2>/dev/null; do
             if [[ -r "/proc/$gw_pid/status" ]]; then
                 local rss="0" thr="0" vol="0" nvol="0"
-                while IFS= read -r line; do
+            while IFS= read -r line; do
                     case "$line" in
                         VmRSS:*)             rss=$(echo "$line"          | awk '{print $2}') ;;
                         Threads:*)           thr=$(echo "$line"          | awk '{print $2}') ;;
                         voluntary_ctxt*)     vol=$(echo "$line"          | awk '{print $2}') ;;
                         nonvoluntary_ctxt*)  nvol=$(echo "$line"         | awk '{print $2}') ;;
                     esac
-                done < "/proc/$gw_pid/status"
+            done < <(cat "/proc/$gw_pid/status" 2>/dev/null || true)
                 # schedstat field 2 = cumulative ns the gateway was runnable
                 # but waiting for a CPU (run-queue wait). Rising fast between
                 # samples = CPU starvation — the direct signal behind the
                 # event-loop stalls that lag.window catches only after the fact.
                 local rq_wait_ns="0"
                 if [[ -r "/proc/$gw_pid/schedstat" ]]; then
-                    read -r _ss_oncpu rq_wait_ns _ss_slices < "/proc/$gw_pid/schedstat" 2>/dev/null || rq_wait_ns="0"
+              local schedstat_line=""
+              schedstat_line="$(cat "/proc/$gw_pid/schedstat" 2>/dev/null || true)"
+              if [[ -n "$schedstat_line" ]]; then
+                read -r _ss_oncpu rq_wait_ns _ss_slices <<< "$schedstat_line" || rq_wait_ns="0"
+              fi
                 fi
                 # NDJSON line — same schema as gateway/hal_reader emit.
                 # Atomic O_APPEND under PIPE_BUF (4 KB) so this can't tear.
@@ -460,12 +581,12 @@ if [[ "$DEV" == "1" ]]; then
   exit "$status"
 fi
 
-# ── Production mode: gateway serves built frontend ──
-if [[ "$FRONTEND" == "1" ]]; then
+# ── Production mode: gateway + selectable frontend host ──
+if [[ "$FRONTEND_MODE" == "builtin" ]]; then
   if [[ ! -f "$DIST_DIR/index.html" ]]; then
     echo "ERROR: Built frontend not found at $DIST_DIR" >&2
     echo "Run:  cd $WEBUI_DIR && npm run build" >&2
-    echo "Or set [DISPLAY] WEBUI_FRONTEND = 0 to run gateway/API only." >&2
+    echo "Or set [DISPLAY] WEBUI_FRONTEND to 0, a frontend launcher file, or a static directory." >&2
     exit 1
   fi
 
@@ -496,9 +617,14 @@ if [[ "$FRONTEND" == "1" ]]; then
       "$_C_GREEN" "$_C_RESET" "$_C_CYAN" "$HOST" "$PORT" "$_C_RESET"
   fi
   echo
-else
+elif [[ "$FRONTEND_MODE" == "none" ]]; then
   unset LCNC_WEBUI_DIST_DIR
   echo "lcnc-suite: gateway/API-only mode (WEBUI_FRONTEND=0)"
+else
+  unset LCNC_WEBUI_DIST_DIR
+  echo "lcnc-suite: external frontend mode ($FRONTEND_MODE)"
+  echo "  frontend source: $FRONTEND_PATH"
+  echo "  frontend url:    http://${FRONTEND_HOST}:${FRONTEND_PORT}/"
 fi
 
 # Single signal authority: terminal signals reach the launcher only;
@@ -509,12 +635,13 @@ GATEWAY_PID=""
 _term() {
   trap '' INT TERM
   _log "PROD _term: signal received"
+  _stop_frontend_host
   if [[ -n "$GATEWAY_PID" ]]; then
     _log "PROD _term: SIGTERM → gateway pid=$GATEWAY_PID"
     kill -TERM "$GATEWAY_PID" 2>/dev/null
   fi
   _log "PROD _term: waiting for gateway pid=$GATEWAY_PID (≤2s, then SIGKILL)"
-  _wait_or_kill "$GATEWAY_PID" "PROD"
+  _wait_or_kill "$GATEWAY_PID" "PROD" "gateway"
   _stop_hal_sampler
   _stop_proc_status_loop
   _log "PROD _term: gateway reaped, exit 0"
@@ -530,12 +657,37 @@ trap _term INT TERM
 setsid python3 -m uvicorn gateway:app --host "$HOST" --port "$PORT" --app-dir "$GATEWAY_DIR" "${UVICORN_LOOP[@]}" "${UVICORN_COLOR[@]}" "${UVICORN_GRACEFUL[@]}" "${UVICORN_WS[@]}" &
 GATEWAY_PID=$!
 _log "PROD gateway started pid=$GATEWAY_PID"
+if [[ "$FRONTEND_MODE" == "command" || "$FRONTEND_MODE" == "static" ]]; then
+  _start_frontend_host
+  if [[ "$BROWSER" == "1" ]]; then
+    ( sleep 1.5 && xdg-open "$FRONTEND_URL" 2>/dev/null ) &
+  fi
+fi
 _start_hal_sampler "PROD"
 _start_proc_status_loop "$GATEWAY_PID" "PROD"
 # `|| status=$?` keeps set -e from killing us when the gateway exits
 # non-zero (e.g. status=143 after SIGTERM). We need to propagate the
 # status to LinuxCNC's Cleanup via `exit "$status"` below.
 status=0
-wait "$GATEWAY_PID" || status=$?
+if [[ -n "$FRONTEND_PID" ]]; then
+  finished_pid=""
+  wait -n -p finished_pid "$GATEWAY_PID" "$FRONTEND_PID" || status=$?
+  _log "PROD main wait returned status=$status finished_pid=$finished_pid"
+  if [[ "$finished_pid" == "$FRONTEND_PID" ]]; then
+    if [[ "$status" -eq 0 ]]; then
+      status=1
+    fi
+    _log "PROD main: frontend exited first, stopping gateway pid=$GATEWAY_PID"
+    kill -TERM "$GATEWAY_PID" 2>/dev/null || true
+    _wait_or_kill "$GATEWAY_PID" "PROD" "gateway"
+  else
+    _stop_frontend_host
+  fi
+else
+  wait "$GATEWAY_PID" || status=$?
+  _log "PROD main wait returned status=$status"
+fi
+_stop_hal_sampler
+_stop_proc_status_loop
 _log "PROD main wait returned status=$status, exit $status"
 exit "$status"

--- a/lcnc-suite
+++ b/lcnc-suite
@@ -80,13 +80,15 @@ VITE_PORT="5173"
 # interface without an auth token (issue #17). A LAN-reachable gateway with
 # no token is an unauthenticated machine-control surface. Loopback-only
 # (127.0.0.1 / ::1 / localhost) needs no token — single-operator/dev kiosk.
+INSECURE_TEST_MODE="${LCNC_WEBUI_INSECURE:-0}"
 case "$HOST" in
   127.0.0.1|::1|localhost) ;;  # loopback — token optional
   *)
-    if [[ -z "$TOKEN" ]]; then
+    if [[ -z "$TOKEN" && "$INSECURE_TEST_MODE" != "1" ]]; then
       echo "ERROR: WEBUI_HOST='$HOST' exposes the gateway on the network but no WEBUI_TOKEN is set." >&2
       echo "Set WEBUI_TOKEN in the INI [DISPLAY] section (or the LCNC_WEBUI_TOKEN env) to a shared" >&2
       echo "secret, or bind WEBUI_HOST to 127.0.0.1 for a local-only kiosk." >&2
+      echo "For Docker-only test setups, set LCNC_WEBUI_INSECURE=1 to bypass this guard intentionally." >&2
       echo "Refusing to start an unauthenticated machine-control surface." >&2
       exit 1
     fi

--- a/lcnc-suite
+++ b/lcnc-suite
@@ -37,6 +37,7 @@ if [[ -n "$INI_FILE" ]]; then
   PORT="${LCNC_WEBUI_PORT:-$(ini_get WEBUI_PORT)}"
   BROWSER="${LCNC_WEBUI_BROWSER:-$(ini_get WEBUI_BROWSER)}"
   DEV="${LCNC_WEBUI_DEV:-$(ini_get WEBUI_DEV)}"
+  FRONTEND="${LCNC_WEBUI_FRONTEND:-$(ini_get WEBUI_FRONTEND)}"
   CAM_SOURCE="${LCNC_CAMERA_SOURCE:-$(ini_get CAMERA_SOURCE)}"
   CAM_RES="${LCNC_CAMERA_RESOLUTION:-$(ini_get CAMERA_RESOLUTION)}"
   CAM_FPS="${LCNC_CAMERA_FPS:-$(ini_get CAMERA_FPS)}"
@@ -54,6 +55,7 @@ else
   PORT="${LCNC_WEBUI_PORT:-}"
   BROWSER="${LCNC_WEBUI_BROWSER:-}"
   DEV="${LCNC_WEBUI_DEV:-}"
+  FRONTEND="${LCNC_WEBUI_FRONTEND:-}"
   CAM_SOURCE="${LCNC_CAMERA_SOURCE:-}"
   CAM_RES="${LCNC_CAMERA_RESOLUTION:-}"
   CAM_FPS="${LCNC_CAMERA_FPS:-}"
@@ -73,6 +75,7 @@ HOST="${HOST:-0.0.0.0}"
 PORT="${PORT:-8000}"
 BROWSER="${BROWSER:-1}"
 DEV="${DEV:-0}"
+FRONTEND="${FRONTEND:-1}"
 
 VITE_PORT="5173"
 
@@ -458,39 +461,45 @@ if [[ "$DEV" == "1" ]]; then
 fi
 
 # ── Production mode: gateway serves built frontend ──
-if [[ ! -f "$DIST_DIR/index.html" ]]; then
-  echo "ERROR: Built frontend not found at $DIST_DIR" >&2
-  echo "Run:  cd $WEBUI_DIR && npm run build" >&2
-  exit 1
-fi
-
-export LCNC_WEBUI_DIST_DIR="$DIST_DIR"
-
-if [[ "$BROWSER" == "1" ]]; then
-  ( sleep 1.5 && xdg-open "http://localhost:$PORT" 2>/dev/null ) &
-fi
-
-# Print Vite-style banner so the operator sees the LAN URL too. ANSI
-# escapes match Vite's chalk output (green ➜, bold label, cyan URL) so
-# the production startup looks consistent with dev. When HOST=0.0.0.0
-# (default), enumerate both loopback and the first non-loopback IPv4
-# so a remote browser knows what to connect to. When HOST is an
-# explicit IP, print just that.
-_C_GREEN=$'\033[32m'; _C_BOLD=$'\033[1m'; _C_CYAN=$'\033[36m'; _C_RESET=$'\033[0m'
-printf '\n  %slcnc-suite%s %sPROD%s mode\n\n' "$_C_GREEN$_C_BOLD" "$_C_RESET" "$_C_BOLD" "$_C_RESET"
-if [[ "$HOST" == "0.0.0.0" ]]; then
-  printf '  %s➜%s  %sLocal%s:   %shttp://localhost:%s/%s\n' \
-    "$_C_GREEN" "$_C_RESET" "$_C_BOLD" "$_C_RESET" "$_C_CYAN" "$PORT" "$_C_RESET"
-  _LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
-  if [[ -n "$_LAN_IP" ]]; then
-    printf '  %s➜%s  %sNetwork%s: %shttp://%s:%s/%s\n' \
-      "$_C_GREEN" "$_C_RESET" "$_C_BOLD" "$_C_RESET" "$_C_CYAN" "$_LAN_IP" "$PORT" "$_C_RESET"
+if [[ "$FRONTEND" == "1" ]]; then
+  if [[ ! -f "$DIST_DIR/index.html" ]]; then
+    echo "ERROR: Built frontend not found at $DIST_DIR" >&2
+    echo "Run:  cd $WEBUI_DIR && npm run build" >&2
+    echo "Or set [DISPLAY] WEBUI_FRONTEND = 0 to run gateway/API only." >&2
+    exit 1
   fi
+
+  export LCNC_WEBUI_DIST_DIR="$DIST_DIR"
+
+  if [[ "$BROWSER" == "1" ]]; then
+    ( sleep 1.5 && xdg-open "http://localhost:$PORT" 2>/dev/null ) &
+  fi
+
+  # Print Vite-style banner so the operator sees the LAN URL too. ANSI
+  # escapes match Vite's chalk output (green ➜, bold label, cyan URL) so
+  # the production startup looks consistent with dev. When HOST=0.0.0.0
+  # (default), enumerate both loopback and the first non-loopback IPv4
+  # so a remote browser knows what to connect to. When HOST is an
+  # explicit IP, print just that.
+  _C_GREEN=$'\033[32m'; _C_BOLD=$'\033[1m'; _C_CYAN=$'\033[36m'; _C_RESET=$'\033[0m'
+  printf '\n  %slcnc-suite%s %sPROD%s mode\n\n' "$_C_GREEN$_C_BOLD" "$_C_RESET" "$_C_BOLD" "$_C_RESET"
+  if [[ "$HOST" == "0.0.0.0" ]]; then
+    printf '  %s➜%s  %sLocal%s:   %shttp://localhost:%s/%s\n' \
+      "$_C_GREEN" "$_C_RESET" "$_C_BOLD" "$_C_RESET" "$_C_CYAN" "$PORT" "$_C_RESET"
+    _LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+    if [[ -n "$_LAN_IP" ]]; then
+      printf '  %s➜%s  %sNetwork%s: %shttp://%s:%s/%s\n' \
+        "$_C_GREEN" "$_C_RESET" "$_C_BOLD" "$_C_RESET" "$_C_CYAN" "$_LAN_IP" "$PORT" "$_C_RESET"
+    fi
+  else
+    printf '  %s➜%s  %shttp://%s:%s/%s\n' \
+      "$_C_GREEN" "$_C_RESET" "$_C_CYAN" "$HOST" "$PORT" "$_C_RESET"
+  fi
+  echo
 else
-  printf '  %s➜%s  %shttp://%s:%s/%s\n' \
-    "$_C_GREEN" "$_C_RESET" "$_C_CYAN" "$HOST" "$PORT" "$_C_RESET"
+  unset LCNC_WEBUI_DIST_DIR
+  echo "lcnc-suite: gateway/API-only mode (WEBUI_FRONTEND=0)"
 fi
-echo
 
 # Single signal authority: terminal signals reach the launcher only;
 # the trap is the only path that signals the gateway. Trap forwards

--- a/lcnc-webui/src/lcncWs.ts
+++ b/lcnc-webui/src/lcncWs.ts
@@ -49,6 +49,7 @@ export interface WsStatus {
   surface_points?: [number, number, number][];
   comp_grid?: any;
   probe_results?: Record<string, number>;
+  disable_reason?: Record<string, any>;
   type?: string;
   timing?: any;
   // Sibling of `data` — gateway injects on tool change / library edit.
@@ -99,6 +100,132 @@ const _compGridErr = ref<string | null>(null);
 export const previewLoadError = computed<string | null>(
   () => _previewErr.value ?? _surfaceErr.value ?? _compGridErr.value,
 );
+
+type StatusSummary = {
+  enabled: boolean;
+  estop: boolean;
+  homed: boolean;
+  emcEnableIn: boolean | null;
+  taskMode: number | null;
+  motionMode: number | null;
+  interpState: number | null;
+  jointDiagnostics: Array<Record<string, any>>;
+};
+
+let _lastStatusSummary: StatusSummary | null = null;
+let _lastSentCommand: { cmd: string; ts: number } | null = null;
+
+function _pushMessage(kind: number, text: string, unread = true): void {
+  messages.value = [...messages.value, { id: _nextMsgId++, kind, text, ts: Date.now() }];
+  if (unread) unreadCount.value++;
+  persistMessages(messages.value);
+}
+
+function _numericOrNull(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function _summarizeStatusData(data: Record<string, any> | undefined): StatusSummary {
+  const safeData = data ?? {};
+  return {
+    enabled: Boolean(safeData.is_enabled ?? safeData.enabled),
+    estop: Boolean(safeData.is_estop ?? safeData.estop),
+    homed: Boolean(safeData.homed),
+    emcEnableIn: safeData.emc_enable_in == null ? null : Boolean(safeData.emc_enable_in),
+    taskMode: Number.isInteger(safeData.task_mode) ? safeData.task_mode : null,
+    motionMode: Number.isInteger(safeData.motion_mode) ? safeData.motion_mode : null,
+    interpState: Number.isInteger(safeData.interp_state) ? safeData.interp_state : null,
+    jointDiagnostics: Array.isArray(safeData.joint_diagnostics) ? safeData.joint_diagnostics : [],
+  };
+}
+
+function _jointName(index: number): string {
+  return `joint${index}`;
+}
+
+function _followingErrorMessages(jointDiagnostics: Array<Record<string, any>>): string[] {
+  const messages: string[] = [];
+  for (const joint of jointDiagnostics) {
+    const index = Number.isInteger(joint?.index) ? joint.index : 0;
+    const current = _numericOrNull(joint?.ferror_current);
+    const highmark = _numericOrNull(joint?.ferror_highmark);
+    const limit = _numericOrNull(joint?.max_ferror);
+    if (limit == null || !(limit > 0)) {
+      continue;
+    }
+    if (current != null && Math.abs(current) >= limit) {
+      messages.push(`${_jointName(index)} following error ${current.toFixed(4)} (limit ${limit.toFixed(4)})`);
+      continue;
+    }
+    if (highmark != null && Math.abs(highmark) >= limit) {
+      messages.push(`${_jointName(index)} following error peak ${highmark.toFixed(4)} (limit ${limit.toFixed(4)})`);
+    }
+  }
+  return messages;
+}
+
+function _recentCommandWas(cmd: string, withinMs: number): boolean {
+  return _lastSentCommand?.cmd === cmd && (Date.now() - _lastSentCommand.ts) < withinMs;
+}
+
+function _emitTransitionMessages(next: StatusSummary, msgErrors: Array<[number, string]> | undefined): void {
+  const prev = _lastStatusSummary;
+  if (!prev) {
+    _lastStatusSummary = next;
+    return;
+  }
+
+  const errorTexts = Array.isArray(msgErrors)
+    ? msgErrors.map((entry) => Array.isArray(entry) ? String(entry[1] ?? "") : "").filter(Boolean)
+    : [];
+  const followingErrors = _followingErrorMessages(next.jointDiagnostics);
+  const followingText = followingErrors[0] ?? "";
+  const disabledTransition = prev.enabled && !next.enabled && !_recentCommandWas("machine_off", 2000);
+  const estopTransition = !prev.estop && next.estop && !_recentCommandWas("estop", 2000);
+
+  if (disabledTransition) {
+    const detail = followingText || errorTexts[0] || "Machine disabled unexpectedly.";
+    _pushMessage(OPERATOR_ERROR, `Machine disabled unexpectedly: ${detail}`);
+  }
+
+  if (estopTransition) {
+    const detail = followingText || errorTexts[0] || "E-stop asserted by LinuxCNC or the safety chain.";
+    _pushMessage(OPERATOR_ERROR, `E-stop asserted: ${detail}`);
+  }
+
+  if (prev.homed && !next.homed) {
+    _pushMessage(OPERATOR_ERROR, "Machine lost homed state.");
+  }
+
+  if (followingErrors.length > 0 && !disabledTransition && !estopTransition) {
+    const newErrors = followingErrors.filter((text) => !_followingErrorMessages(prev.jointDiagnostics).includes(text));
+    for (const text of newErrors) {
+      _pushMessage(OPERATOR_ERROR, text);
+    }
+  }
+
+  _lastStatusSummary = next;
+}
+
+function _disableReasonMessage(disableReason: Record<string, any> | undefined): string | null {
+  if (!disableReason || disableReason.kind !== "machine_disabled") {
+    return null;
+  }
+  const currentErrors = Array.isArray(disableReason.recent_errors) ? disableReason.recent_errors : [];
+  const previousErrors = Array.isArray(disableReason.previous_recent_errors) ? disableReason.previous_recent_errors : [];
+  const firstError = [...currentErrors, ...previousErrors].find((entry: any) => Array.isArray(entry) && entry[1]);
+  if (firstError) {
+    return `Machine disabled unexpectedly: ${String(firstError[1])}`;
+  }
+  const currentCauses = Array.isArray(disableReason.likely_causes) ? disableReason.likely_causes : [];
+  const previousCauses = Array.isArray(disableReason.previous_likely_causes) ? disableReason.previous_likely_causes : [];
+  const firstCause = [...currentCauses, ...previousCauses].find(Boolean);
+  if (firstCause) {
+    return `Machine disabled unexpectedly: ${String(firstCause)}`;
+  }
+  return null;
+}
 // ---------- Browser → server telemetry batcher ----------
 // Posts NDJSON batches to POST /telemetry where the gateway forwards each
 // event to the suite-wide trace bus tagged `browser.<kind>`. Catches the
@@ -692,6 +819,7 @@ function onWorkerMessage(m: any) {
       emitTelemetry("ws.open", { dt_ms: m.dtMs, attempt: m.attempt });
       connected.value = true;
       serverShuttingDown.value = false;
+      _lastStatusSummary = null;
       // Acquire screen wake-lock if enabled (not gated on armed, so passive
       // viewer tabs stay awake too). Released on close.
       try {
@@ -703,6 +831,7 @@ function onWorkerMessage(m: any) {
       emitTelemetry("ws.close", {
         code: m.code, reason: m.reason, clean: m.wasClean, since_attempt_ms: m.sinceAttemptMs,
       });
+      _lastStatusSummary = null;
       connected.value = false;
       // Capture armed state so the worker's NEXT reconnect hello can ask the
       // gateway to restore armed=true via a still-valid armed-resume hold.
@@ -850,6 +979,11 @@ function onFrame(data: string | ArrayBuffer) {
     }
 
     if (msg.type === "status") {
+      const latchedDisableMessage = _disableReasonMessage(msg.disable_reason);
+      if (latchedDisableMessage) {
+        _pushMessage(OPERATOR_ERROR, latchedDisableMessage);
+      }
+
       // Only act on status messages that carry timing (heartbeat-triggered).
       // Plain status messages arrive first and must NOT consume _rtSentAt.
       if (msg.timing) {
@@ -877,10 +1011,12 @@ function onFrame(data: string | ArrayBuffer) {
       const errs: [number, string][] = msg.errors;
       if (Array.isArray(errs) && errs.length > 0) {
         for (const [kind, text] of errs) {
-          messages.value = [...messages.value, { id: _nextMsgId++, kind, text, ts: Date.now() }];
-          unreadCount.value++;
+          _pushMessage(kind, text);
         }
-        persistMessages(messages.value);
+      }
+
+      if (!latchedDisableMessage) {
+        _emitTransitionMessages(_summarizeStatusData(msg.data), errs);
       }
 
       // Preserve tool_meta across batched messages — gateway sends it only
@@ -925,14 +1061,9 @@ function onFrame(data: string | ArrayBuffer) {
           starting: "Run-from-line: starting program…",
         };
         if (rfl.ok === false) {
-          messages.value = [...messages.value, { id: _nextMsgId++, kind: OPERATOR_ERROR,
-            text: `Run-from-line ${rfl.phase}: ${rfl.error || "failed"}`, ts: Date.now() }];
-          unreadCount.value++;
-          persistMessages(messages.value);
+          _pushMessage(OPERATOR_ERROR, `Run-from-line ${rfl.phase}: ${rfl.error || "failed"}`);
         } else if (phaseText[rfl.phase]) {
-          messages.value = [...messages.value, { id: _nextMsgId++, kind: OPERATOR_DISPLAY,
-            text: phaseText[rfl.phase]!, ts: Date.now() }];
-          persistMessages(messages.value);
+          _pushMessage(OPERATOR_DISPLAY, phaseText[rfl.phase]!, false);
         }
       }
 
@@ -968,9 +1099,7 @@ function onFrame(data: string | ArrayBuffer) {
     } else if (msg.type === "reply") {
       lastReply.value = msg;
       if (msg.ok === false && msg.error) {
-        messages.value = [...messages.value, { id: _nextMsgId++, kind: OPERATOR_ERROR, text: `Command: ${msg.error}`, ts: Date.now() }];
-        unreadCount.value++;
-        persistMessages(messages.value);
+        _pushMessage(OPERATOR_ERROR, `Command: ${msg.error}`);
       }
     } else if (msg.type === "viewer_init") {
       viewerInit.value = msg.data;
@@ -1034,6 +1163,7 @@ function onFrame(data: string | ArrayBuffer) {
 }
 
 export function send(obj: WsCommand) {
+  _lastSentCommand = { cmd: obj.cmd, ts: Date.now() };
   if (wsWorker) {
     // Classify here (main thread) where the structured command is visible.
     // Mutating/motion commands must not be queued+replayed across a reconnect


### PR DESCRIPTION
## Summary

This PR adds support for running the frontend separately from the gateway, while keeping cross-origin access explicit and secure.

## Changes

- Added `WEBUI_FRONTEND` to choose how the frontend is hosted:
  - built-in gateway frontend
  - gateway/API only
  - external static directory
  - external frontend process
- Added `WEBUI_FRONTEND_HOST` and `WEBUI_FRONTEND_PORT` for external hosting.
- Updated origin handling so allowed origins can include `*` when that is intentionally needed.
- Updated the example config to document the new options.

## Security

- Same-host browser access still works by default.
- External frontends are cross-origin, so they require explicit `WEBUI_ALLOWED_ORIGINS` configuration unless `*` is intentionally used.
- Token auth remains the main protection for control access; origin checks remain defense-in-depth for browser clients.

## Why

This makes it possible to host the UI outside the gateway without weakening the default security model.